### PR TITLE
feat(doctrine-enum-mapping): Added configurable option (default to of…

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ If not using discovery then add the provider to `config/app.php`:
     OrisIntel\OnlineMigrator\OnlineMigratorServiceProvider::class,
 ```
 
+If changing tables with `enum` columns consider working around "Unknown database
+type enum requested" by tweaking `config/online-migrator.php`:
+``` php
+  'doctrine-enum-mapping' => env('DOCTRINE_ENUM_MAPPING', 'string'),
+```
+or `.env` with `DOCTRINE_ENUM_MAPPING=string`
+
+
 ## Usage
 
 Run Artisan's migrate to apply migrations online*:

--- a/config/online-migrator.php
+++ b/config/online-migrator.php
@@ -48,4 +48,17 @@ return [
     */
 
     'ptosc-options' => env('PTOSC_OPTIONS'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Register Doctrine Enum Type
+    |--------------------------------------------------------------------------
+    |
+    | Works around altering non-enum columns blocked by quirk in Doctrine by
+    | mapping enums to 'string'. Using 'string' does not allow changing enums
+    | themselves with Eloquent like `->enum(...)->change()`. Can pass along any
+    | truthy type name in case there are better alternatives.
+    |
+    */
+    'doctrine-enum-mapping' => env('DOCTRINE_ENUM_MAPPING'),
 ];

--- a/src/OnlineMigrator.php
+++ b/src/OnlineMigrator.php
@@ -35,6 +35,15 @@ class OnlineMigrator extends Migrator
         );
         // END: Copied from parent.
 
+        // CONSIDER: Moving to separate package since this isn't directly
+        // related to online migrations.
+        $enum_mapping = config('online-migrator.doctrine-enum-mapping');
+        if ($enum_mapping) {
+            $db->getDoctrineSchemaManager()
+                ->getDatabasePlatform()
+                ->registerDoctrineTypeMapping('enum', $enum_mapping);
+        }
+
         if (! self::isOnlineAppropriate($migration, $method, $db->getDatabaseName())) {
             return parent::getQueries($migration, $method);
         }

--- a/tests/DoctrineEnumMappingTest.php
+++ b/tests/DoctrineEnumMappingTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace OrisIntel\OnlineMigrator\Tests;
+
+class DoctrineEnumMappingTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+        $app['config']->set('online-migrator.strategy', 'innodb-online-ddl');
+    }
+
+    public function test_migrate_altersWithEnum()
+    {
+        $this->loadMigrationsFrom(__DIR__ . '/migrations/alter-with-enum');
+
+        $name_max_length = \DB::table('information_schema.columns')
+            ->where('table_name', 'test_om')
+            ->where('column_name', 'name')
+            ->value('CHARACTER_MAXIMUM_LENGTH');
+        $this->assertEquals(150, $name_max_length);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,14 +5,23 @@ namespace OrisIntel\OnlineMigrator\Tests;
 
 class TestCase extends \Orchestra\Testbench\TestCase
 {
-    protected function setUp() : void
+    protected function setUp(): void
     {
         parent::setUp();
 
         $this->loadMigrationsFrom(__DIR__ . '/migrations/setup');
     }
 
-    protected function getPackageProviders($app) {
+    protected function getEnvironmentSetUp($app)
+    {
+        // Don't want residual enums to get in the way of other tests, so always
+        // map to string.
+        // CONSIDER: Further isolating tests, each with it's own table(s).
+        $app['config']->set('online-migrator.doctrine-enum-mapping', 'string');
+    }
+
+    protected function getPackageProviders($app)
+    {
         return ['\OrisIntel\OnlineMigrator\OnlineMigratorServiceProvider'];
     }
 }

--- a/tests/migrations/alter-with-enum/0000_00_00_000001_add_enum_to_test_om.php
+++ b/tests/migrations/alter-with-enum/0000_00_00_000001_add_enum_to_test_om.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddEnumToTestOm extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('test_om', function (Blueprint $table) {
+            $table->enum('my_enum', ['A', 'B']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('test_om', function (Blueprint $table) {
+            $table->dropColumn('my_enum');
+        });
+    }
+}

--- a/tests/migrations/alter-with-enum/0000_00_00_000002_alter_with_enum.php
+++ b/tests/migrations/alter-with-enum/0000_00_00_000002_alter_with_enum.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AlterWithEnum extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('test_om', function (Blueprint $table) {
+            $table->string('name', 150)->change();
+            /* TODO: Support changing enum column itself.
+            $table->enum('my_enum', ['A', 'B', 'C'])->change();
+            */
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('test_om', function (Blueprint $table) {
+            $table->string('name', 191)->change();
+            /* TODO: Support changing enum column itself.
+            $table->enum('my_enum', ['A', 'B'])->change();
+            */
+        });
+    }
+}


### PR DESCRIPTION
…f) which can map enums to strings to allow modifying columns on tables with enums without raw SQL.

Much like the `OnlineMigrator` allows using Eloquent queries to transparently get on-line capability, this feature's doctrine-enum-mapping allows using Eloquent queries where they'd be blocked by [this Doctrine enum quirk](http://doctrine-orm.readthedocs.io/projects/doctrine-orm/en/2.6/cookbook/mysql-enums.html).

Not sure how well this fits into the OM or if it's truly needed with Doctrine 2.7+ and PHP 7.1+. (My tests indicate it is still needed.)