### PR TITLE
feat(PtOnlineSchemaChange): Support PTOSC options separated by spaces.

### DIFF
--- a/src/Strategy/PtOnlineSchemaChange.php
+++ b/src/Strategy/PtOnlineSchemaChange.php
@@ -123,7 +123,6 @@ class PtOnlineSchemaChange implements StrategyInterface
         if (! empty($option_csv)) {
             // CONSIDER: Formatting CLI options in config as native arrays
             // instead of CSV.
-            // CONSIDER: Supporting commas embedded in option value like '--option="red,blue"'
             $raw_options = preg_split('/[, ]+(?=--)/', $option_csv);
             foreach ($raw_options as $raw_option) {
                 if (false === strpos($raw_option, '--', 0)) {
@@ -131,7 +130,7 @@ class PtOnlineSchemaChange implements StrategyInterface
                         'Only double dashed (full) options supported '
                         . var_export($raw_option, 1));
                 }
-                $option_root = preg_replace('/^--(no-?|=.*)?/', '', $raw_option);
+                $option_root = preg_replace('/^--(no-?|[= ].*)?/', '', $raw_option);
                 $options[$option_root] = $raw_option;
             }
         }

--- a/src/Strategy/PtOnlineSchemaChange.php
+++ b/src/Strategy/PtOnlineSchemaChange.php
@@ -124,7 +124,7 @@ class PtOnlineSchemaChange implements StrategyInterface
             // CONSIDER: Formatting CLI options in config as native arrays
             // instead of CSV.
             // CONSIDER: Supporting commas embedded in option value like '--option="red,blue"'
-            $raw_options = explode(',', $option_csv);
+            $raw_options = preg_split('/[, ]+(?=--)/', $option_csv);
             foreach ($raw_options as $raw_option) {
                 if (false === strpos($raw_option, '--', 0)) {
                     throw new \InvalidArgumentException(


### PR DESCRIPTION
PTOSC options are split apart temporarily in order to check if they are overwriting any hard-coded defaults. This had assumed all user-provided options were comma separated. In practice users are more likely to use spaces, so this supports spaces as separators whenever they are followed by an option prefix ("--").

For example, one can now specify `PTOSC_OPTIONS="--check-unique-key-change --set-vars lock_wait_timeout=300"` to override the hard-coded `--no-check-unique-key-change` default.