### PR TITLE
Fix/inconsistent trait and env var

### DIFF
--- a/config/online-migrator.php
+++ b/config/online-migrator.php
@@ -14,7 +14,7 @@ return [
     |
     */
 
-    'enabled' => env('USE_ONLINE_MIGRATOR'),
+    'enabled' => env('ONLINE_MIGRATOR'),
 
     /*
     |--------------------------------------------------------------------------

--- a/phpunit.xml.travis
+++ b/phpunit.xml.travis
@@ -30,6 +30,6 @@
     <php>
         <env name="DB_DATABASE" value="test_om"/>
         <env name="DB_USERNAME" value="root"/>
-        <env name="USE_ONLINE_MIGRATOR" value="1"/>
+        <env name="ONLINE_MIGRATOR" value="1"/>
     </php>
 </phpunit>

--- a/src/OnlineIncompatibleWithUp.php
+++ b/src/OnlineIncompatibleWithUp.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace OrisIntel\OnlineMigrator\Traits;
+namespace OrisIntel\OnlineMigrator;
 
 // CONSIDER: Renaming "OnlineCannotMigrateUp"
 trait OnlineIncompatibleWithUp


### PR DESCRIPTION
Drops `\Traits` from `OnlineIncompatibleWithUp` for consistency with other incompatible traits' namespaces.

Drops "USE_" from enabled environment variable for consistency with the community and config name itself.

This would mark version 2.0 since it breaks compatibility with v1.