### PR TITLE
fix(PtOnlineSchemaChange): Prefix FK constraint names with underscore…

### DIFF
--- a/src/Strategy/PtOnlineSchemaChange.php
+++ b/src/Strategy/PtOnlineSchemaChange.php
@@ -57,8 +57,9 @@ class PtOnlineSchemaChange implements StrategyInterface
                 ["default '0'", "default '1'"],
                 ['default 0', 'default 1'], $changes);
 
-            // TODO: Fix dropping FKs by prefixing constraint name with '_' or
-            // '__' if already starts with '_' (quirk in PTOSC).
+            // Dropping FKs with PTOSC requires prefixing constraint name with
+            // '_'; adding another if it already starts with '_'.
+            $changes = preg_replace('/(\bDROP\s+FOREIGN\s+KEY\s+`?)([^`\s]+)/imu', '\01_\02', $changes);
 
             // Keeping defaults here so overriding one does not discard all, as
             // would happen if left to `config/online-migrator.php`.

--- a/tests/PtOnlineSchemaChangeTest.php
+++ b/tests/PtOnlineSchemaChangeTest.php
@@ -11,6 +11,15 @@ class PtOnlineSchemaChangeTest extends TestCase
     // getting output from $this->artisan, Artisan::call, and console Kernel
     // aren't working yet, and loadMigrationsFrom is opaque.
 
+    public function test_getQueryOrCommand_rewritesDropForeignKey()
+    {
+        $query = ['query' => 'ALTER TABLE t DROP FOREIGN KEY fk, DROP FOREIGN KEY fk2'];
+
+        $command = PtOnlineSchemaChange::getQueryOrCommand($query, \DB::connection());
+        $this->assertStringStartsWith('pt-online-schema-change', $command);
+        $this->assertContains("'DROP FOREIGN KEY _fk, DROP FOREIGN KEY _fk2", $command);
+    }
+
     public function test_getQueryOrCommand_rewritesDropIndex()
     {
         $query = ['query' => 'DROP INDEX idx ON test'];


### PR DESCRIPTION
… to work with quirk in PTOSC.

More info at https://www.percona.com/doc/percona-toolkit/LATEST/pt-online-schema-change.html#cmdoption-pt-online-schema-change-alter