### PR TITLE
fix(PtOnlineSchemaChange): Correct PTOSC_OPTIONS overrides of default…

### DIFF
--- a/src/Strategy/PtOnlineSchemaChange.php
+++ b/src/Strategy/PtOnlineSchemaChange.php
@@ -106,7 +106,7 @@ class PtOnlineSchemaChange implements StrategyInterface
      *
      * @return string
      */
-    private static function getOptionsForShell(?string $option_csv, array $defaults = []) : string
+    public static function getOptionsForShell(?string $option_csv, array $defaults = []) : string
     {
         $return = '';
 
@@ -131,7 +131,7 @@ class PtOnlineSchemaChange implements StrategyInterface
                         'Only double dashed (full) options supported '
                         . var_export($raw_option, 1));
                 }
-                $option_root = preg_replace('/^--(no-?|[= ].*)?/', '', $raw_option);
+                $option_root = preg_replace('/(^--(no-?)?|[= ].*)?/', '', $raw_option);
                 $options[$option_root] = $raw_option;
             }
         }

--- a/tests/PtOnlineSchemaChangeTest.php
+++ b/tests/PtOnlineSchemaChangeTest.php
@@ -11,6 +11,13 @@ class PtOnlineSchemaChangeTest extends TestCase
     // getting output from $this->artisan, Artisan::call, and console Kernel
     // aren't working yet, and loadMigrationsFrom is opaque.
 
+    public function test_getOptionsForShell_overridesDefault()
+    {
+        $this->assertEquals(
+            ' --alter-foreign-keys-method=none',
+            PtOnlineSchemaChange::getOptionsForShell('--alter-foreign-keys-method=none', ['--alter-foreign-keys-method=auto']));
+    }
+
     public function test_getQueryOrCommand_rewritesDropForeignKey()
     {
         $query = ['query' => 'ALTER TABLE t DROP FOREIGN KEY fk, DROP FOREIGN KEY fk2'];


### PR DESCRIPTION
… values.

So explicit PTOSC_OPTIONS will appear alone in final PTOSC commands instead of the hard-coded default first, then again with desired value.