### PR TITLE
Feature/combine queries for ptosc

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,13 @@ class MyMigration extends Migration
     use \OrisIntel\OnlineMigrator\InnodbOnlineDdl
 ```
 
+Do not combine queries for a migration when using PTOSC:
+``` php
+class MyMigration extends Migration
+{
+    use \OrisIntel\OnlineMigrator\CombineIncompatible
+```
+
 Adding foreign key with index to existing table:
 ``` php
 class MyColumnWithFkMigration extends Migration

--- a/src/CombineIncompatible.php
+++ b/src/CombineIncompatible.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace OrisIntel\OnlineMigrator;
+
+trait CombineIncompatible
+{
+    /** @var array containing migrate methods incompatible w/combining SQL */
+    public $combineIncompatible = true;
+}

--- a/src/OnlineMigrator.php
+++ b/src/OnlineMigrator.php
@@ -58,11 +58,8 @@ class OnlineMigrator extends Migrator
         // END: Copied from parent.
 
         $strategy = self::getStrategy($migration);
-        foreach ($queries as &$query) {
-            $query['query'] = $strategy::getQueryOrCommand($query, $db);
-        }
 
-        return $queries;
+        return $strategy::getQueriesAndCommands($queries, $db, $migration->combineIncompatible ?? false);
     }
 
     /**

--- a/src/Strategy/StrategyInterface.php
+++ b/src/Strategy/StrategyInterface.php
@@ -7,14 +7,15 @@ use Illuminate\Database\Connection;
 interface StrategyInterface
 {
     /**
-     * Get query or command, converting "ALTER TABLE " statements to on-line commands/queries.
+     * Get queries and commands, converting "ALTER TABLE " statements to on-line commands/queries.
      *
-     * @param array $query
-     * @param array $db_config
+     * @param array $queries
+     * @param array $connection
+     * @param bool  $combineIncompatible
      *
-     * @return string
+     * @return array of queries and--where supported--commands
      */
-    public static function getQueryOrCommand(array &$query, Connection $connection);
+    public static function getQueriesAndCommands(array &$queries, Connection $connection, bool $combineIncompatible = false) : array;
 
     /**
      * Execute query or on-line command.
@@ -26,5 +27,5 @@ interface StrategyInterface
      *
      * @return void
      */
-    public static function runQueryOrCommand(array &$query, Connection $connection);
+    public static function runQueryOrCommand(array &$query, Connection $connection) : void;
 }

--- a/tests/PtOnlineSchemaChangeTest.php
+++ b/tests/PtOnlineSchemaChangeTest.php
@@ -138,6 +138,18 @@ class PtOnlineSchemaChangeTest extends TestCase
         $this->assertContains("'ADD \"c\" INT, DROP \"c2\"", $converted[0]['query']);
     }
 
+    public function test_migrate_doesNotCombineUnsupportedSql()
+    {
+        $queries = [
+            ['query' => 'ALTER TABLE t ADD c INT'],
+            ['query' => 'ALTER TABLE t EXCHANGE PARTITION p WITH TABLE t2'],
+        ];
+
+        $converted = PtOnlineSchemaChange::getQueriesAndCommands($queries, \DB::connection());
+        $this->assertCount(2, $converted);
+        $this->assertNotContains(", EXCHANGE PARTITION", $converted[0]['query']);
+    }
+
     public function test_migrate_dropsIndexWithSql()
     {
         $this->loadMigrationsFrom(__DIR__ . '/migrations/creates-index-with-raw-sql');

--- a/tests/PtOnlineSchemaChangeTest.php
+++ b/tests/PtOnlineSchemaChangeTest.php
@@ -125,6 +125,19 @@ class PtOnlineSchemaChangeTest extends TestCase
         \DB::table('test_om_with_primary')->insert(['name' => 'alice']);
     }
 
+    public function test_migrate_combinesAdjacentDdl()
+    {
+        $queries = [
+            ['query' => 'ALTER TABLE "t" ADD "c" INT'],
+            ['query' => 'ALTER TABLE "t" DROP "c2"'],
+        ];
+
+        $converted = PtOnlineSchemaChange::getQueriesAndCommands($queries, \DB::connection());
+        $this->assertCount(1, $converted);
+        $this->assertStringStartsWith('pt-online-schema-change', $converted[0]['query']);
+        $this->assertContains("'ADD \"c\" INT, DROP \"c2\"", $converted[0]['query']);
+    }
+
     public function test_migrate_dropsIndexWithSql()
     {
         $this->loadMigrationsFrom(__DIR__ . '/migrations/creates-index-with-raw-sql');

--- a/tests/PtOnlineSchemaChangeTest.php
+++ b/tests/PtOnlineSchemaChangeTest.php
@@ -18,6 +18,14 @@ class PtOnlineSchemaChangeTest extends TestCase
             PtOnlineSchemaChange::getOptionsForShell('--alter-foreign-keys-method=none', ['--alter-foreign-keys-method=auto']));
     }
 
+    public function test_getQueryOrCommand_doesntRewriteTableRename()
+    {
+        $query = ['query' => 'ALTER TABLE `t` RENAME `t2`'];
+
+        $query_or_command = PtOnlineSchemaChange::getQueryOrCommand($query, \DB::connection());
+        $this->assertEquals($query['query'], $query_or_command);
+    }
+
     public function test_getQueryOrCommand_rewritesDropForeignKey()
     {
         $query = ['query' => 'ALTER TABLE t DROP FOREIGN KEY fk, DROP FOREIGN KEY fk2'];

--- a/tests/PtOnlineSchemaChangeTest.php
+++ b/tests/PtOnlineSchemaChangeTest.php
@@ -136,14 +136,19 @@ class PtOnlineSchemaChangeTest extends TestCase
     public function test_migrate_combinesAdjacentDdl()
     {
         $queries = [
-            ['query' => 'ALTER TABLE "t" ADD "c" INT'],
-            ['query' => 'ALTER TABLE "t" DROP "c2"'],
+            ['query' => 'ALTER TABLE t ADD c INT'],
+            ['query' => 'ALTER TABLE t ALTER c2 SET DEFAULT 0'],
+            ['query' => 'ALTER TABLE t DROP c3'],
+            ['query' => 'ALTER TABLE t CHANGE c4 c4 TEXT'],
+            ['query' => 'ALTER TABLE t2 ADD c INT'],
+            ['query' => 'ALTER TABLE t2 ADD c2 INT'],
         ];
 
         $converted = PtOnlineSchemaChange::getQueriesAndCommands($queries, \DB::connection());
-        $this->assertCount(1, $converted);
+        $this->assertCount(2, $converted);
         $this->assertStringStartsWith('pt-online-schema-change', $converted[0]['query']);
-        $this->assertContains("'ADD \"c\" INT, DROP \"c2\"", $converted[0]['query']);
+        $this->assertContains('ADD c INT, ALTER c2 SET DEFAULT 0, DROP c3, CHANGE c4 c4 TEXT', $converted[0]['query']);
+        $this->assertContains('ADD c INT, ADD c2 INT', $converted[1]['query']);
     }
 
     public function test_migrate_doesNotCombineUnsupportedSql()

--- a/tests/migrations/creates-fk-with-index/0000_00_00_000001_create_fk_with_index.php
+++ b/tests/migrations/creates-fk-with-index/0000_00_00_000001_create_fk_with_index.php
@@ -2,6 +2,8 @@
 
 class CreateFkWithIndex extends \Illuminate\Database\Migrations\Migration
 {
+    use \OrisIntel\OnlineMigrator\CombineIncompatible;
+
     public function up()
     {
         Schema::create('test_om_fk_with_index', function (\Illuminate\Database\Schema\Blueprint $table) {


### PR DESCRIPTION
Resolves #12 for most common cases ("ADD, ALTER, DROP, and CHANGE") by combining when using PTOSC.

This is not being done for Innodb's Online DDL since (at least newer versions) already work without multiple copies. Though long term this work may be reused there anyway to help with older Mysql versions and rare cases where online DDL must copy.