### PR TITLE
feat(PtOnlineSchemaChange): Added ptosc-fold-table-case option to wor…

### DIFF
--- a/config/online-migrator.php
+++ b/config/online-migrator.php
@@ -51,6 +51,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Percona Online Schema Change - Fold Table Case
+    |--------------------------------------------------------------------------
+    |
+    | Whether to force table case to 'upper' or 'lower'. Mysql can silently
+    | coerce case but PTOSC cannot.
+    |
+    */
+
+    'ptosc-fold-table-case' => env('PTOSC_FOLD_TABLE_CASE'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Register Doctrine Enum Type
     |--------------------------------------------------------------------------
     |

--- a/src/Strategy/PtOnlineSchemaChange.php
+++ b/src/Strategy/PtOnlineSchemaChange.php
@@ -191,6 +191,16 @@ final class PtOnlineSchemaChange implements StrategyInterface
             return $query['query'];
         }
 
+        $table_name_folded = $onlineable['table_name'];
+        switch(mb_strtolower(config('online-migrator.ptosc-fold-table-case'))) {
+            case 'upper':
+                $table_name_folded = mb_strtoupper($table_name_folded);
+                break;
+            case 'lower':
+                $table_name_folded = mb_strtolower($table_name_folded);
+                break;
+        }
+
         // Keeping defaults here so overriding one does not discard all, as
         // would happen if left to `config/online-migrator.php`.
         $ptosc_defaults = [
@@ -212,7 +222,7 @@ final class PtOnlineSchemaChange implements StrategyInterface
         $db_config = $connection->getConfig();
         $command = 'pt-online-schema-change --alter '
             . escapeshellarg($onlineable['changes'])
-            . ' D=' . escapeshellarg($db_config['database'] . ',t=' . $onlineable['table_name'])
+            . ' D=' . escapeshellarg($db_config['database'] . ',t=' . $table_name_folded)
             . ' --host ' . escapeshellarg($db_config['host'])
             . ' --port ' . escapeshellarg($db_config['port'])
             . ' --user ' . escapeshellarg($db_config['username'])

--- a/tests/PtOnlineSchemaChangeTest.php
+++ b/tests/PtOnlineSchemaChangeTest.php
@@ -12,6 +12,11 @@ class PtOnlineSchemaChangeTest extends TestCase
     // getting output from $this->artisan, Artisan::call, and console Kernel
     // aren't working yet, and loadMigrationsFrom is opaque.
 
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('online-migrator.ptosc-fold-table-case', 'lower');
+    }
+
     public function test_getOptionsForShell_overridesDefault()
     {
         $this->assertEquals(
@@ -25,6 +30,15 @@ class PtOnlineSchemaChangeTest extends TestCase
 
         $query_or_command = PtOnlineSchemaChange::getQueryOrCommand($query, \DB::connection());
         $this->assertEquals($query['query'], $query_or_command);
+    }
+
+    public function test_getQueryOrCommand_foldsTableCaseLower()
+    {
+        $query = ['query' => 'ALTER TABLE `myTable` ADD "c" INT'];
+
+        $command = PtOnlineSchemaChange::getQueryOrCommand($query, \DB::connection());
+        $this->assertStringStartsWith('pt-online-schema-change', $command);
+        $this->assertContains(",t=mytable'", $command);
     }
 
     public function test_getQueryOrCommand_rewritesDropForeignKey()


### PR DESCRIPTION
…karound PTOSC lack of support for forcing table case.

Mysql has a `lower_case_table_names` option which can transparently coerce input case into lower case. PTOSC does not. So this provides an option to also fold table names to lower case when necessary to work with Mysql installs which are similarly forcing case.